### PR TITLE
refactor(has): make Has::get consuming, update all impls, macros, and…

### DIFF
--- a/crates/do_macro/tests/basic.rs
+++ b/crates/do_macro/tests/basic.rs
@@ -67,13 +67,13 @@ struct Ctx {
 }
 
 impl Has<A> for Ctx {
-    fn get(&self) -> &A {
-        &self.a
+    fn get(self) -> A {
+        self.a
     }
 }
 impl Has<B> for Ctx {
-    fn get(&self) -> &B {
-        &self.b
+    fn get(self) -> B {
+        self.b
     }
 }
 
@@ -89,13 +89,13 @@ fn test_struct_field() {
 }
 
 impl Has<A> for (A, B) {
-    fn get(&self) -> &A {
-        &self.0
+    fn get(self) -> A {
+        self.0
     }
 }
 impl Has<B> for (A, B) {
-    fn get(&self) -> &B {
-        &self.1
+    fn get(self) -> B {
+        self.1
     }
 }
 

--- a/crates/field_macro/src/lib.rs
+++ b/crates/field_macro/src/lib.rs
@@ -23,8 +23,8 @@ pub fn derive_has_fields(input: TokenStream) -> TokenStream {
         let field_ty = &field.ty;
         impls.push(quote! {
             impl #impl_generics ::fx::Has<#field_ty> for #name #ty_generics #where_clause {
-                fn get(&self) -> &#field_ty {
-                    &self.#field_name
+                fn get(self) -> #field_ty {
+                    self.#field_name
                 }
             }
         });

--- a/crates/field_macro/tests/struct_field.rs
+++ b/crates/field_macro/tests/struct_field.rs
@@ -8,6 +8,6 @@ fn test_field_struct() {
         b: &'static str,
     }
     let ctx = Ctx { a: 42, b: "hello" };
-    assert_eq!(*<Ctx as Has<u32>>::get(&ctx), 42u32);
-    assert_eq!(*<Ctx as Has<&'static str>>::get(&ctx), "hello");
+    assert_eq!(<Ctx as Has<u32>>::get(ctx.clone()), 42u32);
+    assert_eq!(<Ctx as Has<&'static str>>::get(ctx), "hello");
 }

--- a/crates/fx/src/core/fx.rs
+++ b/crates/fx/src/core/fx.rs
@@ -146,7 +146,7 @@ impl<'f, S: Clone> Fx<'f, S, ()> {
         X: Clone,
     {
         Fx::pending(move |ctx: S| {
-            let x = Has::get(&ctx).clone();
+            let x = Has::get(ctx.clone());
             f(x)
         })
     }

--- a/crates/fx/src/core/has_put.rs
+++ b/crates/fx/src/core/has_put.rs
@@ -4,11 +4,11 @@ pub trait Has<T>
 where
     Self: DynClone,
 {
-    fn get<'f>(&'f self) -> &'f T;
+    fn get(self) -> T;
 }
 
 impl<T: Clone> Has<T> for T {
-    fn get<'f>(&'f self) -> &'f T {
+    fn get(self) -> T {
         self
     }
 }

--- a/crates/fx/src/core/tests/ability_test.rs
+++ b/crates/fx/src/core/tests/ability_test.rs
@@ -103,8 +103,8 @@ fn lift_req_composes_ability_and_state() {
         n: i32,
     }
     impl Has<MyAbility> for Ctx {
-        fn get<'f>(&'f self) -> &'f MyAbility {
-            &self.ab
+        fn get(self) -> MyAbility {
+            self.ab
         }
     }
     impl Put<MyAbility> for Ctx {
@@ -114,8 +114,8 @@ fn lift_req_composes_ability_and_state() {
         }
     }
     impl Has<i32> for Ctx {
-        fn get<'f>(&'f self) -> &'f i32 {
-            &self.n
+        fn get(self) -> i32 {
+            self.n
         }
     }
     impl Put<i32> for Ctx {

--- a/crates/fx/src/core/tests/forall_test.rs
+++ b/crates/fx/src/core/tests/forall_test.rs
@@ -40,13 +40,13 @@ impl Into<(i32, bool)> for S2 {
     }
 }
 impl Has<i32> for S2 {
-    fn get(&self) -> &i32 {
-        &self.x
+    fn get(self) -> i32 {
+        self.x
     }
 }
 impl Has<bool> for S2 {
-    fn get(&self) -> &bool {
-        &self.y
+    fn get(self) -> bool {
+        self.y
     }
 }
 impl Put<i32> for S2 {

--- a/crates/fx/src/core/tests/fx_test.rs
+++ b/crates/fx/src/core/tests/fx_test.rs
@@ -15,8 +15,8 @@ struct S {
     b: B,
 }
 impl Has<A> for S {
-    fn get<'f>(&'f self) -> &'f A {
-        &self.a
+    fn get(self) -> A {
+        self.a
     }
 }
 impl Put<A> for S {
@@ -26,8 +26,8 @@ impl Put<A> for S {
     }
 }
 impl Has<B> for S {
-    fn get<'f>(&'f self) -> &'f B {
-        &self.b
+    fn get(self) -> B {
+        self.b
     }
 }
 impl Put<B> for S {
@@ -157,8 +157,8 @@ fn has_pending_tuple() {
     #[derive(Clone)]
     struct N(i32);
     impl Has<N> for (N, ()) {
-        fn get(&self) -> &N {
-            &self.0
+        fn get(self) -> N {
+            self.0
         }
     }
 
@@ -176,8 +176,8 @@ fn has_pending_struct() {
         x: i32,
     }
     impl Has<i32> for Ctx {
-        fn get<'f>(&'f self) -> &'f i32 {
-            &self.x
+        fn get(self) -> i32 {
+            self.x
         }
     }
     let fx = Fx::has_pending(|x: i32| Fx::value(x * 2));
@@ -194,8 +194,8 @@ fn has_pending_composed() {
         y: i32,
     }
     impl Has<i32> for Ctx {
-        fn get<'f>(&'f self) -> &'f i32 {
-            &self.x
+        fn get(self) -> i32 {
+            self.x
         }
     }
     // Compose two has_pending calls

--- a/crates/fx/src/core/tests/get_n_test.rs
+++ b/crates/fx/src/core/tests/get_n_test.rs
@@ -8,13 +8,13 @@ struct Ctx2 {
     b: u16,
 }
 impl Has<u8> for Ctx2 {
-    fn get(&self) -> &u8 {
-        &self.a
+    fn get(self) -> u8 {
+        self.a
     }
 }
 impl Has<u16> for Ctx2 {
-    fn get(&self) -> &u16 {
-        &self.b
+    fn get(self) -> u16 {
+        self.b
     }
 }
 
@@ -25,18 +25,18 @@ struct Ctx3 {
     c: u32,
 }
 impl Has<u8> for Ctx3 {
-    fn get(&self) -> &u8 {
-        &self.a
+    fn get(self) -> u8 {
+        self.a
     }
 }
 impl Has<u16> for Ctx3 {
-    fn get(&self) -> &u16 {
-        &self.b
+    fn get(self) -> u16 {
+        self.b
     }
 }
 impl Has<u32> for Ctx3 {
-    fn get(&self) -> &u32 {
-        &self.c
+    fn get(self) -> u32 {
+        self.c
     }
 }
 
@@ -48,23 +48,23 @@ struct Ctx4 {
     d: u64,
 }
 impl Has<u8> for Ctx4 {
-    fn get(&self) -> &u8 {
-        &self.a
+    fn get(self) -> u8 {
+        self.a
     }
 }
 impl Has<u16> for Ctx4 {
-    fn get(&self) -> &u16 {
-        &self.b
+    fn get(self) -> u16 {
+        self.b
     }
 }
 impl Has<u32> for Ctx4 {
-    fn get(&self) -> &u32 {
-        &self.c
+    fn get(self) -> u32 {
+        self.c
     }
 }
 impl Has<u64> for Ctx4 {
-    fn get(&self) -> &u64 {
-        &self.d
+    fn get(self) -> u64 {
+        self.d
     }
 }
 
@@ -77,28 +77,28 @@ struct Ctx5 {
     e: usize,
 }
 impl Has<u8> for Ctx5 {
-    fn get(&self) -> &u8 {
-        &self.a
+    fn get(self) -> u8 {
+        self.a
     }
 }
 impl Has<u16> for Ctx5 {
-    fn get(&self) -> &u16 {
-        &self.b
+    fn get(self) -> u16 {
+        self.b
     }
 }
 impl Has<u32> for Ctx5 {
-    fn get(&self) -> &u32 {
-        &self.c
+    fn get(self) -> u32 {
+        self.c
     }
 }
 impl Has<u64> for Ctx5 {
-    fn get(&self) -> &u64 {
-        &self.d
+    fn get(self) -> u64 {
+        self.d
     }
 }
 impl Has<usize> for Ctx5 {
-    fn get(&self) -> &usize {
-        &self.e
+    fn get(self) -> usize {
+        self.e
     }
 }
 
@@ -112,33 +112,33 @@ struct Ctx6 {
     f: i8,
 }
 impl Has<u8> for Ctx6 {
-    fn get(&self) -> &u8 {
-        &self.a
+    fn get(self) -> u8 {
+        self.a
     }
 }
 impl Has<u16> for Ctx6 {
-    fn get(&self) -> &u16 {
-        &self.b
+    fn get(self) -> u16 {
+        self.b
     }
 }
 impl Has<u32> for Ctx6 {
-    fn get(&self) -> &u32 {
-        &self.c
+    fn get(self) -> u32 {
+        self.c
     }
 }
 impl Has<u64> for Ctx6 {
-    fn get(&self) -> &u64 {
-        &self.d
+    fn get(self) -> u64 {
+        self.d
     }
 }
 impl Has<usize> for Ctx6 {
-    fn get(&self) -> &usize {
-        &self.e
+    fn get(self) -> usize {
+        self.e
     }
 }
 impl Has<i8> for Ctx6 {
-    fn get(&self) -> &i8 {
-        &self.f
+    fn get(self) -> i8 {
+        self.f
     }
 }
 
@@ -153,38 +153,38 @@ struct Ctx7 {
     g: i16,
 }
 impl Has<u8> for Ctx7 {
-    fn get(&self) -> &u8 {
-        &self.a
+    fn get(self) -> u8 {
+        self.a
     }
 }
 impl Has<u16> for Ctx7 {
-    fn get(&self) -> &u16 {
-        &self.b
+    fn get(self) -> u16 {
+        self.b
     }
 }
 impl Has<u32> for Ctx7 {
-    fn get(&self) -> &u32 {
-        &self.c
+    fn get(self) -> u32 {
+        self.c
     }
 }
 impl Has<u64> for Ctx7 {
-    fn get(&self) -> &u64 {
-        &self.d
+    fn get(self) -> u64 {
+        self.d
     }
 }
 impl Has<usize> for Ctx7 {
-    fn get(&self) -> &usize {
-        &self.e
+    fn get(self) -> usize {
+        self.e
     }
 }
 impl Has<i8> for Ctx7 {
-    fn get(&self) -> &i8 {
-        &self.f
+    fn get(self) -> i8 {
+        self.f
     }
 }
 impl Has<i16> for Ctx7 {
-    fn get(&self) -> &i16 {
-        &self.g
+    fn get(self) -> i16 {
+        self.g
     }
 }
 
@@ -200,43 +200,43 @@ struct Ctx8 {
     h: i32,
 }
 impl Has<u8> for Ctx8 {
-    fn get(&self) -> &u8 {
-        &self.a
+    fn get(self) -> u8 {
+        self.a
     }
 }
 impl Has<u16> for Ctx8 {
-    fn get(&self) -> &u16 {
-        &self.b
+    fn get(self) -> u16 {
+        self.b
     }
 }
 impl Has<u32> for Ctx8 {
-    fn get(&self) -> &u32 {
-        &self.c
+    fn get(self) -> u32 {
+        self.c
     }
 }
 impl Has<u64> for Ctx8 {
-    fn get(&self) -> &u64 {
-        &self.d
+    fn get(self) -> u64 {
+        self.d
     }
 }
 impl Has<usize> for Ctx8 {
-    fn get(&self) -> &usize {
-        &self.e
+    fn get(self) -> usize {
+        self.e
     }
 }
 impl Has<i8> for Ctx8 {
-    fn get(&self) -> &i8 {
-        &self.f
+    fn get(self) -> i8 {
+        self.f
     }
 }
 impl Has<i16> for Ctx8 {
-    fn get(&self) -> &i16 {
-        &self.g
+    fn get(self) -> i16 {
+        self.g
     }
 }
 impl Has<i32> for Ctx8 {
-    fn get(&self) -> &i32 {
-        &self.h
+    fn get(self) -> i32 {
+        self.h
     }
 }
 
@@ -253,48 +253,48 @@ struct Ctx9 {
     i: i64,
 }
 impl Has<u8> for Ctx9 {
-    fn get(&self) -> &u8 {
-        &self.a
+    fn get(self) -> u8 {
+        self.a
     }
 }
 impl Has<u16> for Ctx9 {
-    fn get(&self) -> &u16 {
-        &self.b
+    fn get(self) -> u16 {
+        self.b
     }
 }
 impl Has<u32> for Ctx9 {
-    fn get(&self) -> &u32 {
-        &self.c
+    fn get(self) -> u32 {
+        self.c
     }
 }
 impl Has<u64> for Ctx9 {
-    fn get(&self) -> &u64 {
-        &self.d
+    fn get(self) -> u64 {
+        self.d
     }
 }
 impl Has<usize> for Ctx9 {
-    fn get(&self) -> &usize {
-        &self.e
+    fn get(self) -> usize {
+        self.e
     }
 }
 impl Has<i8> for Ctx9 {
-    fn get(&self) -> &i8 {
-        &self.f
+    fn get(self) -> i8 {
+        self.f
     }
 }
 impl Has<i16> for Ctx9 {
-    fn get(&self) -> &i16 {
-        &self.g
+    fn get(self) -> i16 {
+        self.g
     }
 }
 impl Has<i32> for Ctx9 {
-    fn get(&self) -> &i32 {
-        &self.h
+    fn get(self) -> i32 {
+        self.h
     }
 }
 impl Has<i64> for Ctx9 {
-    fn get(&self) -> &i64 {
-        &self.i
+    fn get(self) -> i64 {
+        self.i
     }
 }
 
@@ -310,13 +310,13 @@ fn get2_extracts_tuple_from_context() {
         bar: Bar,
     }
     impl Has<Foo> for Ctx {
-        fn get(&self) -> &Foo {
-            &self.foo
+        fn get(self) -> Foo {
+            self.foo
         }
     }
     impl Has<Bar> for Ctx {
-        fn get(&self) -> &Bar {
-            &self.bar
+        fn get(self) -> Bar {
+            self.bar
         }
     }
     let ctx = Ctx {

--- a/crates/fx/src/core/tests/has_put_test.rs
+++ b/crates/fx/src/core/tests/has_put_test.rs
@@ -3,7 +3,7 @@ use crate::core::has_put::{Has, HasPut, Put};
 #[test]
 fn has_and_put_for_u32() {
     let x: u32 = 7;
-    assert_eq!(*x.get(), 7);
+    assert_eq!(x.get(), 7);
     let y = x.put(42);
     assert_eq!(y, 42);
 }
@@ -11,7 +11,7 @@ fn has_and_put_for_u32() {
 #[test]
 fn has_and_put_for_string() {
     let s: String = "hello".to_owned();
-    assert_eq!(s.get(), "hello");
+    assert_eq!(s.clone().get(), "hello".to_owned());
     let t = s.put("world".to_owned());
     assert_eq!(t, "world");
 }

--- a/crates/fx/src/core/tests/lens_test.rs
+++ b/crates/fx/src/core/tests/lens_test.rs
@@ -10,8 +10,8 @@ struct Ctx {
 }
 
 impl Has<u32> for Ctx {
-    fn get(&self) -> &u32 {
-        &self.a
+    fn get(self) -> u32 {
+        self.a
     }
 }
 impl Put<u32> for Ctx {
@@ -28,8 +28,8 @@ struct ST {
 }
 
 impl Has<i32> for ST {
-    fn get(&self) -> &i32 {
-        &self.a
+    fn get(self) -> i32 {
+        self.a
     }
 }
 impl Put<i32> for ST {
@@ -39,8 +39,8 @@ impl Put<i32> for ST {
     }
 }
 impl Has<String> for ST {
-    fn get(&self) -> &String {
-        &self.b
+    fn get(self) -> String {
+        self.b
     }
 }
 impl Put<String> for ST {
@@ -62,7 +62,7 @@ impl ST {
 fn from_has_put_lens() {
     let lens: Lens<Ctx, u32> = Lens::new();
     let ctx = Ctx { a: 1, b: "hi" };
-    assert_eq!(lens.get(ctx.clone()), 1);
+    assert_eq!(<Ctx as Has<u32>>::get(ctx.clone()), 1);
     let updated = lens.set(ctx, 42);
     assert_eq!(updated, Ctx { a: 42, b: "hi" });
 }
@@ -146,8 +146,8 @@ fn prepend_composes_lenses() {
         st: ST,
     }
     impl Has<ST> for Outer {
-        fn get(&self) -> &ST {
-            &self.st
+        fn get(self) -> ST {
+            self.st
         }
     }
     impl Put<ST> for Outer {
@@ -165,7 +165,7 @@ fn prepend_composes_lenses() {
     let st_lens = Lens::<Outer, ST>::new();
     let a_lens = Lens::<ST, i32>::new();
     let composed = a_lens.prepend(st_lens);
-    assert_eq!(composed.get(outer.clone()), 5);
+    assert_eq!(Lens::get(&composed, outer.clone()), 5);
     let updated = composed.set(outer, 99);
     assert_eq!(updated.st.a, 99);
 }
@@ -179,8 +179,8 @@ fn append_composes_lenses() {
         st: ST,
     }
     impl Has<ST> for Outer {
-        fn get(&self) -> &ST {
-            &self.st
+        fn get(self) -> ST {
+            self.st
         }
     }
     impl Put<ST> for Outer {
@@ -198,7 +198,7 @@ fn append_composes_lenses() {
     let st_lens = Lens::<Outer, ST>::new();
     let a_lens = Lens::<ST, i32>::new();
     let composed = st_lens.append(a_lens);
-    assert_eq!(composed.get(outer.clone()), 5);
+    assert_eq!(Lens::get(&composed, outer.clone()), 5);
     let updated = composed.set(outer, 123);
     assert_eq!(updated.st.a, 123);
 }
@@ -207,7 +207,7 @@ fn append_composes_lenses() {
 fn left_lens_accesses_left_of_tuple() {
     let pair: (i32, &str) = (10, "hi");
     let left = Lens::<'_, (i32, &str), i32>::left::<&str>();
-    assert_eq!(left.get(pair.clone()), 10);
+    assert_eq!(Lens::get(&left, pair.clone()), 10);
     let updated = left.set(pair, 42);
     assert_eq!(updated.0, 42);
 }
@@ -216,7 +216,7 @@ fn left_lens_accesses_left_of_tuple() {
 fn right_lens_accesses_right_of_tuple() {
     let pair: (i32, &str) = (10, "hi");
     let right = Lens::<'_, (i32, &str), &str>::right::<i32>();
-    assert_eq!(right.get(pair.clone()), "hi");
+    assert_eq!(Lens::get(&right, pair.clone()), "hi");
     let updated = right.set(pair, "bye");
     assert_eq!(updated.1, "bye");
 }

--- a/crates/lens_macro/src/lib.rs
+++ b/crates/lens_macro/src/lib.rs
@@ -57,8 +57,8 @@ pub fn derive_has_put(input: TokenStream) -> TokenStream {
         let fty = &f.ty;
         quote! {
             impl #impl_generics ::fx::Has<#fty> for #name #ty_generics #where_clause {
-                fn get(&self) -> &#fty {
-                    &self.#fname
+                fn get(self) -> #fty {
+                    self.#fname
                 }
             }
         }


### PR DESCRIPTION
… tests 🦀

BREAKING CHANGE: The Has trait now requires fn get(self) -> T, replacing the previous reference-based API. All manual and macro-generated Has impls, as well as all test and usage code, have been updated to match. This enables more ergonomic value extraction and aligns with strict TDD and incremental refactoring rules. Lens API and macro crates were also updated for compatibility. Future work: consider ergonomic helpers for reference extraction if needed, and audit downstream crates for usage patterns.